### PR TITLE
Remove unused numpy dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
   download_url = 'https://github.com/ThomasNeve/pySldWrap/archive/v0.1.tar.gz',
   keywords = ['solidworks', 'wrapper'],
   install_requires=[            # I get to this in a second
-          'numpy',
           'pywin32',
           'pathlib'
       ],


### PR DESCRIPTION
I have realized that `numpy` is not used in the code, so not requiring it could play nicer on small installations.